### PR TITLE
Add contact section with form on homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,3 +11,6 @@ body { background:#f4f6fb; font-family: system-ui, -apple-system, Segoe UI, Robo
 .price { color:#3a4ed5; font-weight:700; }
 #cart-table table { width:100%; border-collapse: collapse; }
 #cart-table th, #cart-table td { border-bottom:1px solid #eee; padding:8px; text-align:left; }
+
+.main-contact img { max-width:100%; border-radius:10px; }
+.main-contact form { background:#fff; padding:15px; border-radius:10px; box-shadow:0 4px 12px rgba(0,0,0,.08); }

--- a/index.html
+++ b/index.html
@@ -4,11 +4,32 @@ title: "ПакТочка — упаковочные материалы опто�
 description: "Коробки, курьерские пакеты, стрейч-пленка, скотч. Екатеринбург. Самовывоз и доставка. Оплата по счёту для ИП и ООО."
 permalink: /
 ---
-<section class="hero my-4">
-  <h1>Упаковочные материалы для вашего бизнеса</h1>
-  <p>Коробки, пакеты, пленка, скотч — в наличии и под заказ. Екатеринбург и доставка по РФ.</p>
-  <p><a class="btn btn-gradient" href="{{ site.baseurl }}/katalog/">Перейти в каталог</a></p>
+<section class="main-contact my-4">
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <img src="{{ site.baseurl }}/assets/img/korobka-10-10-10.jpg" alt="Упаковочные материалы" class="img-fluid">
+      <p>Коробки и другая упаковка для вашего бизнеса — закажите онлайн.</p>
+    </div>
+    <div class="col-md-6">
+      <form method="POST" action="https://formspree.io/f/XXXXXXXX">
+        <div class="mb-3">
+          <label for="contact-name" class="form-label">Имя</label>
+          <input type="text" id="contact-name" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label for="contact-email" class="form-label">Email</label>
+          <input type="email" id="contact-email" name="_replyto" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label for="contact-message" class="form-label">Сообщение</label>
+          <textarea id="contact-message" name="message" class="form-control" rows="4" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-gradient">Отправить</button>
+      </form>
+    </div>
+  </div>
 </section>
+
 <section class="my-5">
   <h2>Почему мы</h2>
   <ul class="benefits">


### PR DESCRIPTION
## Summary
- Replace hero section with contact section including image, description and Formspree form
- Style new contact section for responsive layout

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689650b89af883319d66eaa5e6cec9bc