### PR TITLE
Fix layout of popular items section

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@ permalink: /
       <div class="cat__img"></div>
       <div class="cat__cap">Прочее</div>
     </a>
-{% include home-popular.html %}
   </div>
 </section>
+
+{% include home-popular.html %}


### PR DESCRIPTION
## Summary
- move `home-popular` block outside of the categories grid so popular products display as tiles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*


------
https://chatgpt.com/codex/tasks/task_e_689e1c69214083319b99bb6ff1417424