### PR TITLE
Добавлены иконки преимуществ и стили

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/cart.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-cats.css?v=1">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-popular.css?v=1">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-benefits.css?v=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">

--- a/assets/css/home-benefits.css
+++ b/assets/css/home-benefits.css
@@ -1,0 +1,8 @@
+.benefits-list{list-style:none;padding:0;margin:0 0 20px;}
+.benefit-item{display:flex;align-items:flex-start;margin-bottom:12px;}
+.benefit-icon{width:32px;height:32px;margin-right:10px;}
+.benefit-icon use{fill:url(#benefit-gradient);}
+@media (max-width:600px){
+  .benefit-icon{width:28px;height:28px;margin-right:8px;}
+  .benefit-item{margin-bottom:10px;}
+}

--- a/assets/img/benefits/assortment.svg
+++ b/assets/img/benefits/assortment.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <symbol id="icon" viewBox="0 0 32 32">
+    <defs>
+      <linearGradient id="benefit-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#6f83ff"/>
+        <stop offset="100%" stop-color="#c19aff"/>
+      </linearGradient>
+    </defs>
+    <g fill="url(#benefit-gradient)">
+      <rect x="2" y="2" width="12" height="12" rx="2"/>
+      <rect x="18" y="2" width="12" height="12" rx="2"/>
+      <rect x="10" y="18" width="12" height="12" rx="2"/>
+    </g>
+  </symbol>
+</svg>

--- a/assets/img/benefits/delivery.svg
+++ b/assets/img/benefits/delivery.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <symbol id="icon" viewBox="0 0 32 32">
+    <defs>
+      <linearGradient id="benefit-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#6f83ff"/>
+        <stop offset="100%" stop-color="#c19aff"/>
+      </linearGradient>
+    </defs>
+    <g fill="url(#benefit-gradient)">
+      <rect x="2" y="10" width="18" height="10" rx="2"/>
+      <rect x="20" y="14" width="8" height="6" rx="2"/>
+      <circle cx="10" cy="24" r="3"/>
+      <circle cx="24" cy="24" r="3"/>
+    </g>
+  </symbol>
+</svg>

--- a/assets/img/benefits/discount.svg
+++ b/assets/img/benefits/discount.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <symbol id="icon" viewBox="0 0 32 32">
+    <defs>
+      <linearGradient id="benefit-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#6f83ff"/>
+        <stop offset="100%" stop-color="#c19aff"/>
+      </linearGradient>
+    </defs>
+    <g stroke="url(#benefit-gradient)" stroke-width="3" fill="none" stroke-linecap="round">
+      <circle cx="10" cy="10" r="4"/>
+      <circle cx="22" cy="22" r="4"/>
+      <line x1="22" y1="10" x2="10" y2="22"/>
+    </g>
+  </symbol>
+</svg>

--- a/assets/img/benefits/reliability.svg
+++ b/assets/img/benefits/reliability.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <symbol id="icon" viewBox="0 0 32 32">
+    <defs>
+      <linearGradient id="benefit-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#6f83ff"/>
+        <stop offset="100%" stop-color="#c19aff"/>
+      </linearGradient>
+    </defs>
+    <path fill="url(#benefit-gradient)" d="M16 2 L28 6 V16 C28 24 22 29 16 30 C10 29 4 24 4 16 V6 Z"/>
+  </symbol>
+</svg>

--- a/assets/img/benefits/supply.svg
+++ b/assets/img/benefits/supply.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <symbol id="icon" viewBox="0 0 32 32">
+    <defs>
+      <linearGradient id="benefit-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#6f83ff"/>
+        <stop offset="100%" stop-color="#c19aff"/>
+      </linearGradient>
+    </defs>
+    <g fill="url(#benefit-gradient)">
+      <rect x="6" y="12" width="20" height="14" rx="2"/>
+      <path d="M16 2 L8 10 H24 Z"/>
+    </g>
+  </symbol>
+</svg>

--- a/index.html
+++ b/index.html
@@ -110,3 +110,39 @@ permalink: /
 </section>
 
 {% include home-popular.html %}
+
+<section class="home-section">
+  <h2 class="section-title">Наши преимущества</h2>
+  <ul class="benefits-list">
+    <li class="benefit-item">
+      <svg class="benefit-icon">
+        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/assortment.svg#icon"></use>
+      </svg>
+      <span>Широкий ассортимент — более 500 наименований в наличии.</span>
+    </li>
+    <li class="benefit-item">
+      <svg class="benefit-icon">
+        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/supply.svg#icon"></use>
+      </svg>
+      <span>Стабильные поставки — работаем напрямую с производителями.</span>
+    </li>
+    <li class="benefit-item">
+      <svg class="benefit-icon">
+        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/delivery.svg#icon"></use>
+      </svg>
+      <span>Быстрая доставка — отправляем заказы по всей России.</span>
+    </li>
+    <li class="benefit-item">
+      <svg class="benefit-icon">
+        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/discount.svg#icon"></use>
+      </svg>
+      <span>Скидки и акции — выгодные условия для оптовиков.</span>
+    </li>
+    <li class="benefit-item">
+      <svg class="benefit-icon">
+        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/reliability.svg#icon"></use>
+      </svg>
+      <span>Надёжность — соблюдаем сроки и качество.</span>
+    </li>
+  </ul>
+</section>


### PR DESCRIPTION
## Summary
- добавлены 5 SVG-иконок преимуществ с градиентом
- создан и подключён блок "Наши преимущества" на главной
- вынесены стили блока в `home-benefits.css`

## Testing
- `jekyll build` *(fails: The minima theme could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74658a47c833189dca5327f0616bb