### PR TITLE
Add advantages grid section to homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,3 +13,37 @@
 
 .main-contact img { max-width:100%; border-radius:10px; }
 .main-contact form { background:#fff; padding:15px; border-radius:10px; box-shadow:0 4px 12px rgba(0,0,0,.08); }
+
+.advantages {
+  padding: 50px 20px;
+  text-align: center;
+}
+
+.advantages h2 {
+  font-size: 28px;
+  margin-bottom: 30px;
+}
+
+.advantages-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.advantage-item {
+  background: linear-gradient(135deg, #6a11cb, #2575fc); /* твой сине-фиолетовый градиент */
+  color: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  transition: transform 0.2s ease;
+}
+
+.advantage-item:hover {
+  transform: translateY(-5px);
+}
+
+.advantage-item .icon {
+  font-size: 36px;
+  margin-bottom: 15px;
+}

--- a/index.html
+++ b/index.html
@@ -111,38 +111,28 @@ permalink: /
 
 {% include home-popular.html %}
 
-<section class="home-section">
-  <h2 class="section-title">Наши преимущества</h2>
-  <ul class="benefits-list">
-    <li class="benefit-item">
-      <svg class="benefit-icon">
-        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/assortment.svg#icon"></use>
-      </svg>
-      <span>Широкий ассортимент — более 500 наименований в наличии.</span>
-    </li>
-    <li class="benefit-item">
-      <svg class="benefit-icon">
-        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/supply.svg#icon"></use>
-      </svg>
-      <span>Стабильные поставки — работаем напрямую с производителями.</span>
-    </li>
-    <li class="benefit-item">
-      <svg class="benefit-icon">
-        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/delivery.svg#icon"></use>
-      </svg>
-      <span>Быстрая доставка — отправляем заказы по всей России.</span>
-    </li>
-    <li class="benefit-item">
-      <svg class="benefit-icon">
-        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/discount.svg#icon"></use>
-      </svg>
-      <span>Скидки и акции — выгодные условия для оптовиков.</span>
-    </li>
-    <li class="benefit-item">
-      <svg class="benefit-icon">
-        <use xlink:href="{{ site.baseurl }}/assets/img/benefits/reliability.svg#icon"></use>
-      </svg>
-      <span>Надёжность — соблюдаем сроки и качество.</span>
-    </li>
-  </ul>
+<section class="advantages">
+  <h2>Наши преимущества</h2>
+  <div class="advantages-grid">
+    <div class="advantage-item">
+      <div class="icon">📦</div>
+      <h3>Большой ассортимент</h3>
+      <p>Все упаковочные материалы в одном месте: коробки, пакеты, скотч, плёнка и многое другое.</p>
+    </div>
+    <div class="advantage-item">
+      <div class="icon">🏭</div>
+      <h3>Напрямую с производства</h3>
+      <p>Работаем без посредников — лучшие цены и контроль качества.</p>
+    </div>
+    <div class="advantage-item">
+      <div class="icon">🚚</div>
+      <h3>Быстрая доставка</h3>
+      <p>Доставляем заказы по Екатеринбургу и по всей России.</p>
+    </div>
+    <div class="advantage-item">
+      <div class="icon">🤝</div>
+      <h3>Надёжный партнёр</h3>
+      <p>Сотрудничаем с бизнесом любого масштаба — от магазинов до маркетплейсов.</p>
+    </div>
+  </div>
 </section>


### PR DESCRIPTION
## Summary
- replace benefits list with new advantages section on home page
- style advantages section with gradient cards and responsive grid

## Testing
- `jekyll build` *(fails: command not found: jekyll)*
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a75401710c833189e3ec5d66bbf7c4