### PR TITLE
Update home CTA gradient and outline styles

### DIFF
--- a/assets/css/home-cta.css
+++ b/assets/css/home-cta.css
@@ -104,10 +104,10 @@
 .home-cta .btn--primary,
 .home-cta .cta-form button[type="submit"],
 .home-cta .home-cta__form button[type="submit"]{
-  background:linear-gradient(90deg,#6f42ff 0%, #4dabff 100%);
+  background:linear-gradient(90deg,#6f83ff,#c19aff);
   color:#fff;
   border:none;
-  box-shadow:0 6px 18px rgba(111,66,255,.25);
+  box-shadow:0 6px 18px rgba(111,131,255,.25);
 }
 
 .home-cta .btn-primary:hover,
@@ -121,14 +121,14 @@
 /* ОБВОДКА: поддержка .btn-outline и .btn--ghost */
 .home-cta .btn-outline,
 .home-cta .btn--ghost{
-  border:2px solid #6f42ff;
-  color:#6f42ff;
+  border:2px solid #6f83ff;
+  color:#6f83ff;
   background:transparent;
 }
 
 .home-cta .btn-outline:hover,
 .home-cta .btn--ghost:hover{
-  background:rgba(111,66,255,.08);
+  background:rgba(111,131,255,.08);
 }
 
 /* Примечание под формой */


### PR DESCRIPTION
## Summary
- refresh home CTA primary buttons with a new purple-to-lilac gradient and matching shadow
- align outline/ghost button colors with the new primary palette

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a9e41e194c8331881603bda8acf54d