### PR TITLE
Единый стиль ссылок каталога

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -47,3 +47,13 @@
   font-size: 36px;
   margin-bottom: 15px;
 }
+
+.cats .cat,
+.cats .cat:visited,
+.cats .cat:hover,
+.card a,
+.card a:visited,
+.card a:hover {
+    color:#000;
+    text-decoration:none;
+}

--- a/katalog/katalog-index.md
+++ b/katalog/katalog-index.md
@@ -18,7 +18,7 @@ permalink: /katalog/
 
 <style>
   .cat-links{ display:flex; gap:18px; flex-wrap:wrap; margin:12px 0 22px; }
-  .cat-links a{ color:#6f83ff; font-weight:800; text-decoration:underline; }
+  .cat-links a{ color:#000; text-decoration:none; }
   .cat-links a:hover{ filter:brightness(0.9); }
 </style>
 


### PR DESCRIPTION
## Summary
- Убрал подсветку и подчёркивание ссылок в каталоге, сделав их чёрными
- Добавил глобальные правила для ссылок категорий и карточек товаров
- Проверил, что style.css подключён через основной шаблон, используемый страницами каталога

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aa0abe518c8331a354553b7bd9a56e