### PR TITLE
chore: update cat-links style

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -47,3 +47,7 @@
   font-size: 36px;
   margin-bottom: 15px;
 }
+
+.cat-links { display:flex; gap:18px; flex-wrap:wrap; margin:12px 0 22px; }
+.cat-links a { color:#000; font-weight:800; text-decoration:none; }
+.cat-links a:hover { filter:brightness(0.9); }

--- a/katalog/katalog-index.md
+++ b/katalog/katalog-index.md
@@ -16,12 +16,6 @@ permalink: /katalog/
   <a href="{{ site.baseurl }}/katalog/prochie/">Прочее</a>
 </nav>
 
-<style>
-  .cat-links{ display:flex; gap:18px; flex-wrap:wrap; margin:12px 0 22px; }
-  .cat-links a{ color:#6f83ff; font-weight:800; text-decoration:underline; }
-  .cat-links a:hover{ filter:brightness(0.9); }
-</style>
-
 <div class="grid">
 {% assign items = site.data.products %}
 {% for p in items %}


### PR DESCRIPTION
## Summary
- remove inline catalog style block
- add cat-links styles to global stylesheet with black, bold links

## Testing
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ac52e58833186868c8dfb1de16e