### PR TITLE
Ensure home page category titles stay white

### DIFF
--- a/assets/css/home-cats.css
+++ b/assets/css/home-cats.css
@@ -24,6 +24,12 @@
 }
 .home-section .cat:hover{ transform:translateY(-2px); box-shadow:0 14px 36px rgba(0,0,0,.14); }
 
+.home-section .cat,
+.home-section .cat:visited,
+.home-section .cat:hover {
+  color: #fff;
+}
+
 .home-section .cat .cat__img{
   padding:16px 16px 0;
   display:flex;align-items:center;justify-content:center;


### PR DESCRIPTION
## Summary
- Keep home page category titles white in default, visited and hover states

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4988b9fc8331b7c34b1d6b43d903