### PR TITLE
Fix cat link color and cache version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/font-roboto.css?v=1">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/header.css?v=1">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/cart.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-cats.css?v=1">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-cats.css?v=2">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-popular.css?v=1">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/home-benefits.css?v=1">
   <link rel="stylesheet" href="{{ '/assets/css/home-cta.css?v=2' | relative_url }}">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,10 +57,7 @@
 
 .cats .cat,
 .cats .cat:visited,
-.cats .cat:hover,
-.card a,
-.card a:visited,
-.card a:hover {
-    color:#000;
+.cats .cat:hover {
+    color:#fff;
     text-decoration:none;
 }


### PR DESCRIPTION
## Summary
- ensure cat links render with white text
- bump home-cats CSS version to refresh cache

## Testing
- `jekyll build` *(fails: The minima theme could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4dff2a508331a1540fc700b94cb5