### PR TITLE
fix card image proportions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,7 @@
 .grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap:16px; }
 .card { border:none; border-radius:15px; box-shadow:0 4px 12px rgba(0,0,0,.08); overflow:hidden; transition:transform .2s ease; padding:12px; background:#fff; }
 .card:hover { transform: translateY(-4px); }
-.card img { width:100%; height:180px; object-fit:cover; border-radius:10px; }
+.card img { width:100%; aspect-ratio:1/1; height:auto; object-fit:cover; border-radius:10px; }
 .card a,
 .card a:visited,
 .card a:hover {


### PR DESCRIPTION
## Summary
- keep catalog card images square by removing fixed height and using aspect-ratio

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: tunnel error while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af57ec29a8833194410125647e6646