### PR TITLE
Remove SKU display from product layout

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -40,7 +40,6 @@ layout: default
 
   <div>
     <h1>{{ page.name }}</h1>
-    <p style="color:#666">Артикул: {{ page.sku }}</p>
     <p style="font-size:1.2rem;color:#1a237e;font-weight:700">{{ page.price }} {{ page.unit }}</p>
     {% if page.min_qty %}<p>Минимальный заказ: {{ page.min_qty }}</p>{% endif %}
     <p>{{ page.short }}</p>


### PR DESCRIPTION
## Summary
- remove paragraph that displayed the SKU

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b0927ce1a483319b394062c551566f