### PR TITLE
Handle missing product category with back link

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -7,6 +7,7 @@ layout: default
 если нет — из _data/products.yml по slug.
 {% endcomment %}
 {% assign product_record = site.data.products | where: "slug", page.slug | first %}
+{% assign category = page.category | default: product_record.category %}
 {% assign photo_src = nil %}
 {% assign photo_src = page.images | first %}
 {% unless photo_src %}
@@ -51,12 +52,12 @@ layout: default
       Добавить в корзину
     </button>
 
-    <div style="margin-top:20px;">
-      <a href="{{ ('/katalog/' | append: page.category | append: '/') | relative_url }}" style="margin-right:12px;">← Вернуться в категорию</a>
-      <a href="{{ '/katalog/' | relative_url }}">Каталог</a>
+      <div style="margin-top:20px;">
+        <a href="{{ ('/katalog/' | append: category | append: '/') | relative_url }}">← Вернуться в категорию</a>
+        <a href="{{ '/katalog/' | relative_url }}">Каталог</a>
+      </div>
     </div>
-  </div>
-</article>
+  </article>
 
 <section class="mt-5">
   <h2>С этим покупают</h2>


### PR DESCRIPTION
## Summary
- derive category from front matter or product data
- fix product page back link to use derived category

## Testing
- `jekyll build`
- `grep -n "Вернуться" _site/katalog/korobki/korobka-10x10x10-t23b/index.html`
- `grep -n "Вернуться" _site/katalog/pakety/paket-kurierski-100x150/index.html`
- `grep -n "Вернуться" _site/katalog/skotch/skotch-48-66-prozrachny/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4820936848331b1b6712cf447737e