### PR TITLE
Use category variable in product breadcrumbs

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -19,8 +19,8 @@ layout: default
 <nav aria-label="breadcrumb" style="margin:10px 0; font-size:.95rem;">
   <a href="{{ '/' | relative_url }}">Главная</a> ›
   <a href="{{ '/katalog/' | relative_url }}">Каталог</a> ›
-  <a href="{{ ('/katalog/' | append: page.category | append: '/') | relative_url }}">
-    {% case page.category %}
+  <a href="{{ '/katalog/' | append: category | append: '/' | relative_url }}">
+    {% case category %}
       {% when "korobki" %}Коробки
       {% when "pakety" %}Пакеты
       {% when "skotch" %}Скотч
@@ -53,7 +53,7 @@ layout: default
     </button>
 
       <div style="margin-top:20px;">
-        <a href="{{ ('/katalog/' | append: category | append: '/') | relative_url }}">← Вернуться в категорию</a>
+        <a href="{{ '/katalog/' | append: category | append: '/' | relative_url }}">← Вернуться в категорию</a>
         <a href="{{ '/katalog/' | relative_url }}">Каталог</a>
       </div>
     </div>
@@ -65,8 +65,8 @@ layout: default
     {% assign related = site.data.products | where_exp: "item", "item.category != page.category" | sample: 4 %}
     {% for p in related %}
       <div class="card">
-        <a href="{{ ('/katalog/' | append: p.category | append: '/' | append: p.slug | append: '/') | relative_url }}">
-          <img src="{{ (p.images | first) | relative_url }}" alt="{{ p.name }}">
+        <a href="{{ '/katalog/' | append: p.category | append: '/' | append: p.slug | append: '/' | relative_url }}">
+          <img src="{{ p.images | first | relative_url }}" alt="{{ p.name }}">
           <h3>{{ p.name }}</h3>
         </a>
         <p class="price">{{ p.price }} {{ p.unit }}</p>


### PR DESCRIPTION
## Summary
- Use the preassigned `category` variable for breadcrumb category link
- Reference `category` in the breadcrumb label switch
- Simplify related product links to avoid Liquid warnings

## Testing
- `jekyll build`
- Inspected generated product page without `page.category` to verify breadcrumb link resolves to correct category


------
https://chatgpt.com/codex/tasks/task_e_68b484d38bac833186a1323165d02c2a