### PR TITLE
Remove catalog link from product page layout

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -54,7 +54,6 @@ layout: default
 
       <div style="margin-top:20px;">
         <a href="{{ '/katalog/' | append: category | append: '/' | relative_url }}">← Вернуться в категорию</a>
-        <a href="{{ '/katalog/' | relative_url }}">Каталог</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
## Summary
- remove redundant catalog link from product layout so only back-to-category anchor remains

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b4865dd6b0833188bc9f06c2b1623c