### PR TITLE
Add blog link to main navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,7 @@
         <a href="{{ site.baseurl }}/opt/">Опт</a>
         <a href="{{ site.baseurl }}/dostavka/">Доставка</a>
         <a href="{{ site.baseurl }}/oplata/">Оплата</a>
+        <a href="{{ site.baseurl }}/blog/">Блог</a>
         <a href="{{ site.baseurl }}/contacts/">Контакты</a>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add a Blog item to the main navigation bar in the default layout so that it links to /blog/

## Testing
- `jekyll build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cecc0f4ad08331b3bf9f5933f2c935